### PR TITLE
#17 自動処理が最後まで終わった後、ボタンを切り替える

### DIFF
--- a/src/popup/popupEventListener.ts
+++ b/src/popup/popupEventListener.ts
@@ -77,6 +77,9 @@ export function popupEventListener(zombies: ZombiesMap | null) {
           decreaseZombiesNum(zombiesNum);
         }
       }
+
+      allPurgeButton.style.display = "flex";
+      allPurgeStopButton.style.display = "none";
     });
 
     allPurgeStopButton.addEventListener("click", (event) => {


### PR DESCRIPTION
全員死刑の処理が終わり、残り人数が0人になっても停止ボタンのままなので、もとのボタンに切り替える。