### PR TITLE
#42 間違ったタブを閉じることがある

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "description": "Twitterのインプレゾンビをワンクリックでブロックし、自動で通報します。",
   "version": "1.1",
   "manifest_version": 3,
-  "permissions": ["storage"],
+  "permissions": ["storage", "tabs"],
   "icons": {
     "16": "./icons/zombieHunter.png",
     "48": "./icons/zombieHunter.png",

--- a/src/popup/eventListeners/lib.ts
+++ b/src/popup/eventListeners/lib.ts
@@ -1,3 +1,4 @@
+import { purgeZombieParam, removeZombieParam } from "../../lib/consts.ts";
 import { sleep } from "../../lib/lib.ts";
 import {
   tweetURLClassName,
@@ -47,13 +48,21 @@ export function setZombiesNum(num: number) {
 }
 
 export function closeTab() {
-  chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
-    const tab = tabs.at(0)?.id;
-    if (tab) {
-      chrome.tabs.remove(tab);
-    } else {
-      await sleep(500);
-      closeTab();
+  chrome.tabs.query({}, async (tabs) => {
+    for (const tab of tabs) {
+      if (tab.url === undefined || tab.id === undefined) {
+        continue;
+      }
+
+      const params = new URL(tab.url).searchParams;
+
+      if (params.get(removeZombieParam) || params.get(purgeZombieParam)) {
+        chrome.tabs.remove(tab.id);
+        return;
+      }
     }
+
+    await sleep(500);
+    closeTab();
   });
 }


### PR DESCRIPTION
全てのタブのURLを取得し、`removeZombieParam`もしくは`purgeZombieParam`が含まれているタブのみを閉じるようにした。

なお、タブのURLを取得するためにtab権限を追加した。